### PR TITLE
fix: rename qed to kiwied

### DIFF
--- a/7C.typ
+++ b/7C.typ
@@ -24,4 +24,4 @@ Since $Y = X without {p}$ is open, ${p}$ is closed.
   In a general topological space $X$, we say that $S subset.eq X$ is #glossary[closed] in $X$ if the complement $X without S$ is open in $X$.
 ]
 
-#qed
+#kiwied

--- a/7E.typ
+++ b/7E.typ
@@ -26,4 +26,4 @@ This is contradiction, so $C$ is connected.
 
 The connected components of $p in bb(Q)$ is not an open subset of $bb(Q)$.
 
-#qed
+#kiwied

--- a/8.1.3.b.typ
+++ b/8.1.3.b.typ
@@ -16,4 +16,4 @@ For all subsequence ${x_(gamma_n)}$, $d(x_1, x_(gamma_n)) > n - 1$, so ${x_(gamm
 
 This is contradiction, so $X$ is not compact.
 
-#qed
+#kiwied

--- a/8.4.3.typ
+++ b/8.4.3.typ
@@ -20,4 +20,4 @@ Since $f$ is continuous, $f^("img")(x_(gamma_k)) = y_(gamma_k)$ is a convergent 
 
 Therefore, $f^("img")(X)$ is compact.
 
-#qed
+#kiwied

--- a/8D.typ
+++ b/8D.typ
@@ -12,4 +12,4 @@ For any finite subset of $C$, the union is some $C_n$, and every $C_n$ is not $X
 
 Since $X$ is compact and $C$ doesn't have a finite subset which covers $X$, $C$ is not an open cover.
 
-Thus $inter_(n in NN) K_n != empty$. $square$
+Thus $inter_(n in NN) K_n != empty$. #sym.qed

--- a/8E.typ
+++ b/8E.typ
@@ -18,4 +18,4 @@ $exists n_2 in NN. d(y_(j_n), y) < epsilon/2$
 
 $forall n > max(n_1, n_2). " " d(z_(j_n), (x,y)) < epsilon$
 
-Thus $z_(j_n) -> (x,y)$. $square$
+Thus $z_(j_n) -> (x,y)$. #sym.qed

--- a/template/napkin.typ
+++ b/template/napkin.typ
@@ -8,14 +8,14 @@
 /// -> content
 #let empty = text(font: "New Computer Modern")[#sym.nothing]
 
-/// End of the proof.
+/// End of the proof, kiwi style.
 ///
 /// ```example
-/// #qed
+/// #kiwied
 /// ```
 ///
 /// -> content
-#let qed = align(right)[#sym.star mic drop #sym.star]
+#let kiwied = align(right)[#sym.star mic drop #sym.star]
 
 /// Dagger.
 ///


### PR DESCRIPTION
To avoid the leading cause of murder, rename qed to kiwied.