### PR TITLE
Add new Korean font and format check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,25 @@
+name: check
+on: [pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - id: cache-typstyle
+        uses: actions/cache@v4
+        with:
+          path: typstyle
+          key: ${{ runner.os }}-typstyle-0.13.3
+      - if: steps.cache-typstyle.outputs.cache-hit != 'true'
+        run: |
+          curl -L -o typstyle https://github.com/Enter-tainer/typstyle/releases/download/v0.13.3/typstyle-x86_64-unknown-linux-gnu && \
+          chmod +x typstyle
+      - run: ./typstyle format-all --check
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: typst-community/setup-typst@v4
+        with:
+          typst-version: ^0.13.0
+      - run: ./x build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 name: build-then-deploy
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
 
 jobs:
   deploy:
-    # Only in main branch
-    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-24.04
     environment:
       name: github-pages
@@ -22,18 +22,22 @@ jobs:
       - uses: typst-community/setup-typst@v4
         with:
           typst-version: ^0.13.0
-      # Latin Modern Sans is not installed with typst
+      # Fonts not installed with typst
       - id: cache-fonts
         uses: actions/cache@v4
         with:
           path: fonts
-          key: ${{ runner.os }}-fonts
+          key: ${{ runner.os }}-fonts-1
       - if: steps.cache-fonts.outputs.cache-hit != 'true'
         run: |
-          curl -L -o latin-modern.zip https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip && \
+          curl -L -o latin-modern.zip \
+            'https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip' && \
           unzip latin-modern.zip -d fonts && \
-          curl -L -o Pretendard.zip https://github.com/orioncactus/pretendard/releases/download/v1.3.9/Pretendard-1.3.9.zip && \
-          unzip -j Pretendard.zip "public/static/*.otf" -d fonts
+          curl -L -o Bareonbatang.zip \
+            --referer 'https://copyright.keris.or.kr/wft/fntDwnldView' \
+            -d 'fntGrpId=GFT202301120000000000002&fntFileId=FTF202312080000000000070' \
+            'https://copyright.keris.or.kr/cmm/fntDwnldById' && \
+          unzip Bareonbatang.zip '*.otf' -d fonts
       - run: ./x build
         env:
           TYPST_FONT_PATHS: ./fonts
@@ -42,15 +46,3 @@ jobs:
           path: dist
       - id: deployment
         uses: actions/deploy-pages@v4
-  build:
-    if: ${{ github.ref != 'refs/heads/main' }}
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-      - uses: typst-community/setup-typst@v4
-        with:
-          typst-version: ^0.13.0
-      - run: ./x build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "tinymist.formatterMode": "typstyle"
+}

--- a/1A.typ
+++ b/1A.typ
@@ -1,9 +1,7 @@
 #import "template/napkin.typ": *
 #import "template/napkin-users.typ": *
 
-#plain_box(
-  title: "Problem 1A",
-)[
+#plain_box(title: "Problem 1A")[
   What is the joke in the following figure? (Source: [#link(<img:snsd>)[#text(fill: color.rgb("339901"))[*Ge*]]].)
 ]
 

--- a/7.3.1.typ
+++ b/7.3.1.typ
@@ -1,8 +1,6 @@
 #import "template/napkin.typ": *
 
-#black_note(
-  "Definition 7.3.1",
-)[
+#black_note("Definition 7.3.1")[
   A topological space $X$ is #glossary[Hausdorff] if for any two distinct points $p$ and $q$ in $X$, there exists an open
   neighborhood $U$ of $p$ and an open neighborhood $V$ of $q$ such that
   $

--- a/8.3.1.typ
+++ b/8.3.1.typ
@@ -1,8 +1,6 @@
 #import "template/napkin.typ": *
 
-#black_note(
-  "Definition 8.3.1",
-)[
+#black_note("Definition 8.3.1")[
   An open cover of a topological space $X$ is a collection of open sets ${U_alpha}$ (possibly infinite or uncountable)
   which _cover_ it: every point in $X$ lies in at least one of the $U_alpha$, so that
   $

--- a/8B.typ
+++ b/8B.typ
@@ -6,9 +6,7 @@
   conditions is $X$ compact?
 ]
 
-#solution(
-  users.simnalamburt,
-)[
+#solution(users.simnalamburt)[
   $X$는 이산공간이므로 아래와 $X$를 구성하는 집합은 아래와 같은 꼴이고
 
   $

--- a/8C.typ
+++ b/8C.typ
@@ -9,9 +9,7 @@
   complements of finite sets. This makes $X$ into a topological space. Show that $X$ is quasicompact but not Hausdorff.
 ]
 
-#solution(
-  users.ranolp,
-)[
+#solution(users.ranolp)[
   #enum[
     For any open cover ${U_alpha}$, fix a non-empty open set $S in {U_alpha}$. \
     Due to cofinite topology, $S^C = X without S$ is finite. \

--- a/8E.typ
+++ b/8E.typ
@@ -12,9 +12,9 @@ Let $(y_(j_n))$ be the converging subsequence of $(z_(i_n))$ projected to $Y$. L
 
 Then $forall epsilon in RR^+$,
 
-$exists n_1 in NN. " " forall n >= n_1. " " d(x_(j_n), x) < epsilon/2$
+$exists n_1 in NN. " " forall n >= n_1. " " d(x_(j_n), x) < epsilon / 2$
 
-$exists n_2 in NN. " " forall n >= n_2. " " d(y_(j_n), y) < epsilon/2$
+$exists n_2 in NN. " " forall n >= n_2. " " d(y_(j_n), y) < epsilon / 2$
 
 $forall n >= max(n_1, n_2). " " d(z_(j_n), (x,y)) < epsilon$
 

--- a/8F.typ
+++ b/8F.typ
@@ -4,38 +4,39 @@
 #import "template/napkin-users.typ": *
 
 #chili(1)
-#plain_box(title: [Problem 8F#dagger], subtitle: [Bolzano-Weierstraß theorem for general metric spaces])[
+#plain_box(
+  title: [Problem 8F#dagger],
+  subtitle: [Bolzano-Weierstraß theorem for general metric spaces],
+)[
   Prove that a metric space $M$ is sequentially compact if and only if it is complete and totally bounded.
 ]
 
-#solution(
-  users.ranolp,
-)[
+#solution(users.ranolp)[
   == sequentially compact $arrow.double.r$ complete and totally bounded
 
-  #list(
-    spacing: 2em,
-  )[
+  #list(spacing: 2em)[
     Given a Cauchy sequence $(x_n)$, because $M$ is sequentially compact, \
     there exists a subsequence of $(x_n)$ called $(x_n_k)$
     which converges to $x$.
 
     #grid(columns: 2, column-gutter: 0.75em, row-gutter: 1em)[
       *Claim.*
-    ][$(x_n) -> x$][*Proof.*][ For any $epsilon > 0$:
+    ][$(x_n) -> x$][*Proof.*][
+      For any $epsilon > 0$:
 
       $
-        exists N_1& "such that"& forall n, m &>= N_1,&" " d(x_n, x_m) < epsilon/2 \
-        exists K  & "such that"& forall k    &>= K,  &" " d(x_n_k, x) < epsilon/2
+        exists N_1& "such that"& forall n, m &>= N_1,&" " d(x_n, x_m) < epsilon / 2 \
+        exists K & "such that"& forall k &>= K, &" " d(x_n_k, x) < epsilon / 2
       $
 
       Let's choose $N = max { N_1, n_K }$, then for any $n >= N$, pick a $k >= K$ with #box[$n_k >= n$]. \
       Because of triangle inequality:
       $
-        d(x_n, x) <= d(x_n, x_(n_k)) + d(x_(n_k), x) < epsilon/2 + epsilon/2 = epsilon
+        d(x_n, x) <= d(x_n, x_(n_k)) + d(x_(n_k), x) < epsilon / 2 + epsilon / 2 = epsilon
       $
 
-      Hence $(x_n) -> x$ $square$ ]
+      Hence $(x_n) -> x$ $square$
+    ]
 
     Thus, any Cauchy sequence in $M$ converges.
 
@@ -56,8 +57,8 @@
   Since $M$ is totally bounded, we can cover whole space with finitely many $epsilon$-balls. \
 
   For any $k in NN$ and any sequence $(y_n)$ by _Infinite Pigeonhole Principle_, \
-  we can pick a #box[$1/k$-ball] called $A_k$ containing infinitely many terms in $(y_n)$ \
-  because $1/k$-balls are finitely many.
+  we can pick a #box[$1 / k$-ball] called $A_k$ containing infinitely many terms in $(y_n)$ \
+  because $1 / k$-balls are finitely many.
 
   Let's call the subsequence of $(y_n)$ contained by $A_k$ as $(y^((k))_n)$
 
@@ -72,9 +73,9 @@
   Now let's define a subsequence $(x_n_k)$ which is Cauchy. \
   Inductively pick $n_1 < n_2 < dots.c$ with $x_n_k in (x_n_(Gamma k))$. \
 
-  If $j, k >= N$ then $x_n_j, x_n_k in A_N$ so $d(x_n_j, x_n_k) < "diameter"(A_N) <= 2/N$.
+  If $j, k >= N$ then $x_n_j, x_n_k in A_N$ so $d(x_n_j, x_n_k) < "diameter"(A_N) <= 2 / N$.
 
-  Thus, for $epsilon > 0$, we can pick $N > 2/epsilon$ to meet $d(x_n_j, x_n_k) < epsilon$
+  Thus, for $epsilon > 0$, we can pick $N > 2 / epsilon$ to meet $d(x_n_j, x_n_k) < epsilon$
 
   #line(length: 100%, stroke: 0.25pt)
 

--- a/8H.typ
+++ b/8H.typ
@@ -17,9 +17,9 @@
     A metric space $M$ is #glossary[sequentially compact] if every sequence has a subsequence which converges.
   ]
 
-  Define $f(x) = inf_n (d(x, x_n) + 1/n)$, then $f(x) > 0$ since subsequence of $(x_n)$ never converges.
+  Define $f(x) = inf_n (d(x, x_n) + 1 / n)$, then $f(x) > 0$ since subsequence of $(x_n)$ never converges.
 
-  Define $d'(x, y) = d(x, y) + abs(1/f(x) - 1/f(y))$, then $d'$ is a metric.
+  Define $d'(x, y) = d(x, y) + abs(1 / f(x) - 1 / f(y))$, then $d'$ is a metric.
 
   #plain_box(title: [Definition 2.1.1])[
     A #glossary[metric space] is a pair $(M, d)$ consisting of a set of points $M$ and a #glossary[metric] $d : M times M arrow RR_(>=0)$. The distance function must obey:
@@ -83,12 +83,12 @@
 
   = 3. Unboundedness of $(M, d')$
 
-  Fix a point $p$, then there exists minimum integer $N > 1/f(p)$.
+  Fix a point $p$, then there exists minimum integer $N > 1 / f(p)$.
 
   For all $n in NN$, since $f(x_n) >= n$,
   $
-    d'(p, x_(n+N)) & = d(p, x_(n+N)) + abs(1/f(p) - 1/f(x_(n+N)))
-    \ & >= abs(N - 1/f(x_(n+N)))
+    d'(p, x_(n+N)) & = d(p, x_(n+N)) + abs(1 / f(p) - 1 / f(x_(n+N)))
+    \ & >= abs(N - 1 / f(x_(n+N)))
     \ & >= n.
   $
 

--- a/8I.typ
+++ b/8I.typ
@@ -6,7 +6,7 @@
   (a) Is it possible to partition the plane $RR^2$ into disjoint circles?
 
   (b) From the plane $RR^2$ we delete two distinct points $p$ and $q$.
-      Is it possible to partition the remaining points into disjoint circles?
+  Is it possible to partition the remaining points into disjoint circles?
 ]
 
 (a) No.
@@ -14,21 +14,21 @@
 Suppose $RR^2 = union.plus.big_(C in cal(C)) C$ where $cal(C)$ is a family of circles in $RR^2$.
 
 *Claim.*
-  Let $C_0 in cal(C)$ be a circle whose radius is $r_0$.
-  Then for all $n in NN$, there is a circle $C in cal(C)$ with radius $r$ such that $r <= (1/2)^n r_0$.
+Let $C_0 in cal(C)$ be a circle whose radius is $r_0$.
+Then for all $n in NN$, there is a circle $C in cal(C)$ with radius $r$ such that $r <= (1 / 2)^n r_0$.
 
 _Proof._ Use induction on $n$.
 - *Case:* n = 0.
-  $C_0$ satisfies $r_0 <= (1/2)^0 r_0$.
+  $C_0$ satisfies $r_0 <= (1 / 2)^0 r_0$.
 - *Case:* n = k + 1.
-  Suppose there is $C in cal(C)$ such that $r <= (1/2)^k r_0$ by induction hypothesis.
+  Suppose there is $C in cal(C)$ such that $r <= (1 / 2)^k r_0$ by induction hypothesis.
   Then there is a circle $C' in cal(C)$ containing the center of $C$. Let $r'$ be the radius of $C'$.
-  Since $C'$ must be contained in the inside of $C$, $2r' < r$. Thus $r' <= (1/2)^(k+1) r_0$.
+  Since $C'$ must be contained in the inside of $C$, $2r' < r$. Thus $r' <= (1 / 2)^(k+1) r_0$.
 
-From the claim we proved above, we can choose a sequence of circles ${C_n in cal(C)}$ with radius $r_n$ and center $O_n$ such that $r_n <= (1/2)^n r_0$ by the axiom of countable choice.
+From the claim we proved above, we can choose a sequence of circles ${C_n in cal(C)}$ with radius $r_n$ and center $O_n$ such that $r_n <= (1 / 2)^n r_0$ by the axiom of countable choice.
 Then $O_n$ is a cauchy sequence: Let $epsilon > 0$.
-We can choose $N$ such that $(1/2)^(N-1) r_0 < epsilon$.
-Then for every $m,n >= N$, $|O_m - O_n| < 2r_N <= (1/2)^(N-1) r_0 < epsilon$ since $O_m, O_n$ are contained in the inside of $C_N$.
+We can choose $N$ such that $(1 / 2)^(N-1) r_0 < epsilon$.
+Then for every $m,n >= N$, $|O_m - O_n| < 2r_N <= (1 / 2)^(N-1) r_0 < epsilon$ since $O_m, O_n$ are contained in the inside of $C_N$.
 Thus $O_n -> O$ for some $O$. Let $C in cal(C)$ be the circle containing $O$ and $r$ be the radius of $C$.
-Then $C$ must be contained in the inside of $C_n$ for all $n in N$, implies that $r < r_n <= (1/2)^n r_0$ for all $n$.
+Then $C$ must be contained in the inside of $C_n$ for all $n in N$, implies that $r < r_n <= (1 / 2)^n r_0$ for all $n$.
 But this is a contradiction since the radius of a circle must be positive. #sym.qed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npx serve dist
 To match Napkin's style, some fonts are required:
 
 - [Latin Modern Sans](https://www.gust.org.pl/projects/e-foundry/latin-modern) - For `#blue_box`.
-- [Pretendard](https://github.com/orioncactus/pretendard) - For Korean support.
+- [Hakgyoansim Bareonbatang](https://copyright.keris.or.kr/wft/fntDwnldView?fntGrpId=GFT202301120000000000002) - For Korean support.
 
 You'd better have the following tools for a better contribution experience
 

--- a/template/napkin.typ
+++ b/template/napkin.typ
@@ -6,7 +6,7 @@
 /// ```
 ///
 /// -> content
-#let empty = text(font: "New Computer Modern")[#sym.nothing]
+#let empty = text(sym.nothing, font: "New Computer Modern")
 
 /// End of the proof.
 ///
@@ -15,7 +15,7 @@
 /// ```
 ///
 /// -> content
-#let qed = [#h(1fr) $square$]
+#let qed = [#h(1fr)#text(sym.square, font: "New Computer Modern Math")]
 
 /// Dagger.
 ///
@@ -24,7 +24,7 @@
 /// ```
 ///
 /// -> content
-#let dagger = super(sym.dagger)
+#let dagger = super(text(sym.dagger, font: "New Computer Modern Math"))
 
 /// Star.
 ///
@@ -33,7 +33,7 @@
 /// ```
 ///
 /// -> content
-#let star = super(sym.star)
+#let star = super(text(sym.star, font: "New Computer Modern Math"))
 
 /// Glossary.
 ///
@@ -64,7 +64,10 @@
   /// -> content
   content,
 ) = [
-  #set text(font: "New Computer Modern", size: 11pt)
+  #set text(
+    font: ("New Computer Modern", "Hakgyoansim Bareonbatang"),
+    size: 11pt,
+  )
   #show math.equation: set text(font: "New Computer Modern Math")
   #set par(spacing: 0.8em, justify: true)
   #content
@@ -189,7 +192,10 @@
     y: 1em,
   ),
   latexize[
-    #text(fill: rgb("008000"), font: "Latin Modern Sans")[#titlize(title, subtitle) #sym.dash.em]
+    #text(fill: rgb("008000"), font: "Latin Modern Sans")[#titlize(
+        title,
+        subtitle,
+      ) #sym.dash.em]
     #content
   ],
 )
@@ -314,7 +320,10 @@
   dy: 8pt,
   box(
     width: 60pt,
-    align(right, stack(dir: rtl, ..(image("chili.png", height: 15pt),) * count)),
+    align(
+      right,
+      stack(dir: rtl, ..(image("chili.png", height: 15pt),) * count),
+    ),
   ),
 )
 
@@ -349,9 +358,7 @@
       } else { }
       _by_ #box(baseline: 20%, radius: 2pt, clip: true)[#image(by.avatar.source, format: by.avatar.format, height: 1.2em)] #if by.name != by.login {
         [#by.name (#by.login)]
-      } else {
-        [#by.name]
-      }
+      } else { [#by.name] }
     ]
 
     #line(length: 100%, stroke: 0.5pt + gray)


### PR DESCRIPTION
- Use [Hakgyoansim Bareonbatang](https://copyright.keris.or.kr/wft/fntDwnldView?fntGrpId=GFT202301120000000000002) for serif Korean font.
- Use [typstyle](https://github.com/Enter-tainer/typstyle) to format typst files.
- Run format check only in PRs.
- Cache fonts / binary with specific version keys.